### PR TITLE
Remove trailing slash from `/connect` URL endpoint

### DIFF
--- a/src/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURL.java
@@ -66,7 +66,7 @@ public final class MapillaryURL {
     }
     parts.put("response_type", "token");
     parts.put("scope", "user:read public:upload public:write");
-    return string2URL(BASE_WEBSITE_URL + "connect/"+queryString(parts));
+    return string2URL(BASE_WEBSITE_URL + "connect"+queryString(parts));
   }
 
   /**

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/MapillaryURLTest.java
@@ -63,7 +63,7 @@ public class MapillaryURLTest {
   public void testConnectURL() throws MalformedURLException {
     assertUrlEquals(
         MapillaryURL.connectURL("http://redirect-host/ä"),
-        "https://www.mapillary.com/connect/",
+        "https://www.mapillary.com/connect",
         "client_id=T1Fzd20xZjdtR0s1VDk5OFNIOXpYdzoxNDYyOGRkYzUyYTFiMzgz",
         "scope=user%3Aread+public%3Aupload+public%3Awrite",
         "response_type=token",
@@ -72,7 +72,7 @@ public class MapillaryURLTest {
 
     assertUrlEquals(
         MapillaryURL.connectURL(null),
-        "https://www.mapillary.com/connect/",
+        "https://www.mapillary.com/connect",
         "client_id=T1Fzd20xZjdtR0s1VDk5OFNIOXpYdzoxNDYyOGRkYzUyYTFiMzgz",
         "scope=user%3Aread+public%3Aupload+public%3Awrite",
         "response_type=token"
@@ -80,7 +80,7 @@ public class MapillaryURLTest {
 
     assertUrlEquals(
         MapillaryURL.connectURL(""),
-        "https://www.mapillary.com/connect/",
+        "https://www.mapillary.com/connect",
         "client_id=T1Fzd20xZjdtR0s1VDk5OFNIOXpYdzoxNDYyOGRkYzUyYTFiMzgz",
         "scope=user%3Aread+public%3Aupload+public%3Awrite",
         "response_type=token"


### PR DESCRIPTION
This route is not recognized as valid and when one tries to access it, they get redirected to `mapillary.com/map`. Which is a catch all route for invalid URLs.

It seems that this has been introduced with removing `connect?queryParams` https://github.com/floscher/josm-mapillary-plugin/commit/7aa27f2a9c6963fef86fbae704c5d3f57bab8d17#diff-35986c637f20195f08245de17dea6598L171 and replacing it with `connect/?queryParams`