### PR TITLE
Fix NegativeArraySizeException in ImageUtil.ImageFileFilter

### DIFF
--- a/src/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtil.java
+++ b/src/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtil.java
@@ -145,11 +145,14 @@ public final class ImageUtil {
       }
       try (FileInputStream fis = new FileInputStream(f)) {
         int numBytes = fis.read(magic);
-        return Arrays.equals(JFIF_MAGIC, Arrays.copyOf(magic, Math.min(numBytes, JFIF_MAGIC.length)))
-            || Arrays.equals(PNG_MAGIC, Arrays.copyOf(magic, Math.min(numBytes, PNG_MAGIC.length)));
+        return numBytes >= 0 && (
+          Arrays.equals(JFIF_MAGIC, Arrays.copyOf(magic, Math.min(numBytes, JFIF_MAGIC.length)))
+          || Arrays.equals(PNG_MAGIC, Arrays.copyOf(magic, Math.min(numBytes, PNG_MAGIC.length)))
+        );
       } catch (FileNotFoundException e) {
         return false;
       } catch (IOException e) {
+        Main.warn("IO-exception while reading file "+f.getAbsolutePath());
         return false;
       }
     }

--- a/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtilsTest.java
+++ b/test/unit/org/openstreetmap/josm/plugins/mapillary/utils/ImageUtilsTest.java
@@ -2,6 +2,7 @@
 package org.openstreetmap.josm.plugins.mapillary.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -88,6 +89,12 @@ public class ImageUtilsTest {
   @Test
   public void testUtilityClass() {
     TestUtil.testUtilityClass(ImageUtil.class);
+  }
+
+  @Test
+  public void testFileFilterAgainstEmptyFile() throws URISyntaxException {
+    File f = new File(ImageUtil.class.getResource("/zeroByteFile").toURI());
+    assertFalse(ImageUtil.IMAGE_FILE_FILTER.accept(f));
   }
 
 }


### PR DESCRIPTION
This was reported as https://josm.openstreetmap.de/ticket/13096 .
The fix is accompanied by a testcase to prevent future regressions.